### PR TITLE
Set devcontainer cache

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -19,6 +19,11 @@ RUN groupadd --gid $USER_GID $USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME
 RUN apt-get update && apt-get upgrade -y
 
+# Install memory heavy packages
+RUN apt-get install -y \
+    ros-$ROS_DISTRO-rviz2 \
+    ros-$ROS_DISTRO-ros-gz
+
 # Install essential packages
 RUN apt-get install -y \
     python3-pip \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -35,6 +35,12 @@ RUN apt-get install -y \
 RUN rm -rf /etc/apt/apt.conf.d/docker-clean && \
     apt-get update -y
 
+# Set XDG_RUNTIME_DIR for RViz
+RUN mkdir -p /tmp/runtime-$USERNAME \
+    && chown $USERNAME:$USERNAME /tmp/runtime-$USERNAME \
+    && chmod 0700 /tmp/runtime-$USERNAME
+ENV XDG_RUNTIME_DIR=/tmp/runtime-$USERNAME
+
 ENV SHELL /bin/bash
 
 # [Optional] Set the default user. Omit if you want to keep the default as root.


### PR DESCRIPTION
## Description of contribution in a few bullet points

* Set Rviz2 and Gazebo to be installed earlier to save cache.
* Prevent warnings for RViz2 by setting `XDG_RUNTIME_DIR`.

## Description of how this change was tested

<!--
* I wrote unit tests for my new feature
-->

---
